### PR TITLE
escape markdown for docker run command

### DIFF
--- a/README-NOVELT.md
+++ b/README-NOVELT.md
@@ -41,5 +41,5 @@ scripts/test-and-build-apks-local.sh
 
 ### Get a shell in the container
 - Build the image (see above)
-- docker run -it "${DOCKER_IMAGES_PREFIX}gts_mobile:${APP_VERSION}" bash
+- `docker run -it "${DOCKER_IMAGES_PREFIX}gts_mobile:${APP_VERSION}" bash`
 - now you can execute commands like `./gradlew testGtsReleaseUnitTest` (mind the `./`)


### PR DESCRIPTION
fixes 
![image](https://user-images.githubusercontent.com/37072369/176473210-a52ce033-ecd8-439d-8b79-2152103e0e03.png)
